### PR TITLE
Add subtitle extraction to tv.line.me

### DIFF
--- a/yt_dlp/extractor/line.py
+++ b/yt_dlp/extractor/line.py
@@ -88,6 +88,37 @@ class LineTVIE(InfoExtractor):
         if thumbnail:
             thumbnail = thumbnail.split('?')[0]
 
+        subtitles = {}
+        sub_fan = "-fan"
+        sub_dict = try_get(video_info, lambda x: x['captions']['list']) or {}
+
+        for sub_index in sub_dict:
+            sub_language = try_get(sub_index, lambda x: x['language'])
+            sub_source = try_get(sub_index, lambda x: x['source'])
+            sub_label = try_get(sub_index, lambda x: x['label'])
+            sub_country = try_get(sub_index, lambda x: x['country'])
+            # Checking for fan provided subtitles in already provided languages
+            if subtitles:
+                for subtitle in subtitles.keys():
+                    if subtitle == sub_language + "-" + sub_country or subtitle == sub_language + "-" + sub_country + sub_fan:
+                        sub_lang = sub_language + "-" + sub_country + sub_fan
+                        sub_name = sub_label + sub_fan
+                    else:
+                        sub_lang = sub_language + "-" + sub_country
+                        sub_name = sub_label
+            else:
+                sub_lang = sub_language + "-" + sub_country
+                sub_name = sub_label
+            subtitles.update({
+                sub_lang : [
+                    {
+                        "ext" : "vtt",
+                        "url" : sub_source,
+                        "name": sub_name,
+                    }
+                ]
+            })
+
         return {
             'id': video_id,
             'title': title,
@@ -96,6 +127,7 @@ class LineTVIE(InfoExtractor):
             'duration': duration,
             'thumbnail': thumbnail,
             'view_count': video_info.get('meta', {}).get('count'),
+            'subtitles': subtitles,
         }
 
 


### PR DESCRIPTION
Adds ability to extract subtitles, including fan subtitles from tv.line.me. This has code to workaround the inability of yt-dlp to read parts of vod_play_videoInfo.json. This is needed to stop fan subs from replacing service provided ones of the same language. Normal python has no trouble reading the file but yt-dlp does. Example url for the mentioned problem https://tv.line.me/v/12122117_why-r-u-ep2-1-4/list/561371

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Adds ability to extract subtitles, including fan subtitles from tv.line.me. This has code to workaround the inability of yt-dlp to read parts of vod_play_videoInfo.json. This is needed to stop fan subs from replacing service provided ones of the same language. Normal python has no trouble reading the file but yt-dlp does. Example url for the mentioned problem https://tv.line.me/v/12122117_why-r-u-ep2-1-4/list/561371
